### PR TITLE
Remove unnecessary call to TURN_ON

### DIFF
--- a/custom_components/smart_thermostat/controllers.py
+++ b/custom_components/smart_thermostat/controllers.py
@@ -989,14 +989,6 @@ class ClimatePidController(AbstractPidController):
         return None
 
     async def _async_turn_on(self, reason=None):
-        _LOGGER.info("%s: %s - Turning on climate %s (%s)",
-                     self._thermostat_entity_id,
-                     self.name, self._target_entity_id, reason)
-
-        await self._hass.services.async_call(CLIMATE_DOMAIN, SERVICE_TURN_ON, {
-            ATTR_ENTITY_ID: self._target_entity_id
-        }, context=self._context)
-
         _LOGGER.debug("%s: %s - Setting HVAC mode to %s", self._thermostat_entity_id, self.name, self.mode)
         data = {
             ATTR_ENTITY_ID: self._target_entity_id,


### PR DESCRIPTION
Fixes issue #11 

I removed unnecessary `TURN_ON` service call for climate controller. The `_async_turn_on` method calls both `SERVICE_TURN_ON` and `SERVICE_SET_HVAC_MODE`. They essentially do the same thing because turn on -call sets the mode to what ever it was when turn off was called and right after that mode is set what ever it needs to be.

With my ESPHOME heat pump interface this led to an endless loop when turn on set the mode to `heat_cool` and the controller set the mode to `heat` and that triggered another turn on and so on...